### PR TITLE
fix: resolve besu backward compatibility issue after Ethereum Fusaka hardfork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,18 @@
 ### 🚀 New Features
 - Fixed Besu backward compatibility issues after the Ethereum Fusaka hardfork.
 
+
+## v2.0.0 (2025-05-27)
+
+### 🚀 New Features
+- Server management console added for monitoring and controlling various services.
+
+- Unified control over all services with Start All, Stop All, Status All, and Generate All operations.
+
+- Support for selecting a trust repository, including Hyperledger Besu and Ledger Service Server, with full lifecycle management of those repositories and PostgreSQL (start, stop, status, reset).
+
+- Individual server control enabled with start/stop, status checks, and direct access to Swagger and settings pages.
+
+- Wallet creation supported for each entity via password input.
+
+- DID document generation enabled based on created wallets, also via password input.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,7 @@
 # Changelog
 
-## v2.0.0 (2025-05-27)
+## v2.0.1 (2025-12-18)
 
 ### 🚀 New Features
-- Server management console added for monitoring and controlling various services.
-
-- Unified control over all services with Start All, Stop All, Status All, and Generate All operations.
-
-- Support for selecting a trust repository, including Hyperledger Besu and Ledger Service Server, with full lifecycle management of those repositories and PostgreSQL (start, stop, status, reset).
-
-- Individual server control enabled with start/stop, status checks, and direct access to Swagger and settings pages.
-
-- Wallet creation supported for each entity via password input.
-
-- DID document generation enabled based on created wallets, also via password input.
+- Fixed Besu backward compatibility issues after the Ethereum Fusaka hardfork.
 

--- a/source/did-orchestrator-server/shells/Besu/docker-compose.yml
+++ b/source/did-orchestrator-server/shells/Besu/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   besu:
-    image: docker.io/hyperledger/besu:latest
+    image: docker.io/hyperledger/besu:25.5.0
     container_name: opendid-besu-node
     ports:
       - "8545:8545"


### PR DESCRIPTION
## Description
This PR fixes a besu backward compatibility issue observed after the Ethereum Fusaka hardfork.
The issue was caused by using `docker-compose:latest`, which introduced unexpected behavior.

To resolve this, the docker-compose version has been pinned to `25.5.0`.

## Related Issue (Optional)
N/A

## Changes
- Downgraded docker-compose from `latest` to `25.5.0`
- Restored stable and backward-compatible behavior after the Fusaka hardfork

## Screenshots (Optional)
N/A

## Additional Comments (Optional)
N/A